### PR TITLE
Emergency fix to docker hub build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,6 @@ RUN LDFLAGS=-L/opt/intel/mkl/lib/intel64/ ./configure --without-cuda
 RUN make -j $(nproc)
 RUN make -C python -j $(nproc)
 
-RUN make test
-
 RUN su-exec root:root make install
 RUN su-exec root:root make -C python install
 


### PR DESCRIPTION
due to possibly timeout as testing `make test` is done twice, once in
build stage, once in test stage.

Fix it by deleting the `make test` from Dockerfile.